### PR TITLE
サーバー側がファイルを編集するステップにタイムアウト処理を追加。

### DIFF
--- a/server.py
+++ b/server.py
@@ -110,9 +110,9 @@ class Tcp_server:
                 break
 
         except Exception as err:
-            print(f'[TCP]Error: {str(err)}')
+            print('[TCP]Error: {} {}'.format(str(err), address))
         finally:
-            print('[TCP]closing socket')
+            print('[TCP]closing socket from {} {}'.format(address, self._time_stamp()))
             con.close()
 
     # データ受信処理


### PR DESCRIPTION
・新しい関数run_task()を実装
・タイムアウトエラー処理が発生してもファイルを削除できるよう、新しく編集前・編集後の名を保持する変数を追加。
・クライアントの標準入力に対して、タイムアウト処理を実装
　